### PR TITLE
math    markdown: kramdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ author: Pavlo Shcherbukha
 github: https://github.com/pavlo-shcherbukha
 about: Розробка на Node.js, VUE.js, Python, IBM Integration Bus (App Connect Ent) , ORACLE PL/SQL
 logo: /assets/img/pasha.jpg
-markdown: maruku
+markdown: kramdown
 
 social:
     - icon: fa-linkedin


### PR DESCRIPTION
Ремонтую помилку    
          Error: You're using the 'maruku' Markdown processor, which has been removed as of 3.0.0. We recommend you switch to Kramdown. To do this, replace `markdown: maruku` with `markdown: kramdown` in your `_config.yml` file.
  Logging at level: debug
Configuration file: /github/workspace/./_config.yml